### PR TITLE
fix up 用户标识符SqlParse强制为大写，应该保持用户输入不变

### DIFF
--- a/core/src/main/java/com/dtstack/flink/sql/parser/CreateTableParser.java
+++ b/core/src/main/java/com/dtstack/flink/sql/parser/CreateTableParser.java
@@ -54,7 +54,7 @@ public class CreateTableParser implements IParser {
     public void parseSql(String sql, SqlTree sqlTree) {
         Matcher matcher = PATTERN.matcher(sql);
         if(matcher.find()){
-            String tableName = matcher.group(1).toUpperCase();
+            String tableName = matcher.group(1);
             String fieldsInfoStr = matcher.group(2);
             String propsStr = matcher.group(3);
             Map<String, Object> props = parseProp(propsStr);

--- a/core/src/main/java/com/dtstack/flink/sql/parser/CreateTmpTableParser.java
+++ b/core/src/main/java/com/dtstack/flink/sql/parser/CreateTmpTableParser.java
@@ -21,6 +21,7 @@
 package com.dtstack.flink.sql.parser;
 
 import com.dtstack.flink.sql.util.DtStringUtil;
+import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.*;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -62,11 +63,16 @@ public class CreateTmpTableParser implements IParser {
             String tableName = null;
             String selectSql = null;
             if(matcher.find()) {
-                tableName = matcher.group(1).toUpperCase();
+                tableName = matcher.group(1);
                 selectSql = "select " + matcher.group(2);
             }
 
-            SqlParser sqlParser = SqlParser.create(selectSql);
+            SqlParser.Config config = SqlParser
+                    .configBuilder()
+                    .setLex(Lex.JAVA)
+                    .build();
+            SqlParser sqlParser = SqlParser.create(selectSql,config);
+
             SqlNode sqlNode = null;
             try {
                 sqlNode = sqlParser.parseStmt();
@@ -89,7 +95,7 @@ public class CreateTmpTableParser implements IParser {
                 String tableName = null;
                 String fieldsInfoStr = null;
                 if (matcher.find()){
-                    tableName = matcher.group(1).toUpperCase();
+                    tableName = matcher.group(1);
                     fieldsInfoStr = matcher.group(2);
                 }
                 CreateTmpTableParser.SqlParserResult sqlParseResult = new CreateTmpTableParser.SqlParserResult();

--- a/core/src/main/java/com/dtstack/flink/sql/parser/InsertSqlParser.java
+++ b/core/src/main/java/com/dtstack/flink/sql/parser/InsertSqlParser.java
@@ -20,6 +20,7 @@
 
 package com.dtstack.flink.sql.parser;
 
+import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlJoin;
@@ -57,7 +58,11 @@ public class InsertSqlParser implements IParser {
 
     @Override
     public void parseSql(String sql, SqlTree sqlTree) {
-        SqlParser sqlParser = SqlParser.create(sql);
+        SqlParser.Config config = SqlParser
+                .configBuilder()
+                .setLex(Lex.JAVA)
+                .build();
+        SqlParser sqlParser = SqlParser.create(sql,config);
         SqlNode sqlNode = null;
         try {
             sqlNode = sqlParser.parseStmt();

--- a/core/src/main/java/com/dtstack/flink/sql/side/SideSQLParser.java
+++ b/core/src/main/java/com/dtstack/flink/sql/side/SideSQLParser.java
@@ -21,6 +21,7 @@
 package com.dtstack.flink.sql.side;
 
 import com.dtstack.flink.sql.util.DtStringUtil;
+import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlBasicCall;
@@ -52,11 +53,14 @@ import static org.apache.calcite.sql.SqlKind.*;
 public class SideSQLParser {
 
     public Queue<Object> getExeQueue(String exeSql, Set<String> sideTableSet) throws SqlParseException {
-        exeSql = DtStringUtil.replaceIgnoreQuota(exeSql, "`", "");
         System.out.println("---exeSql---");
         System.out.println(exeSql);
         Queue<Object> queueInfo = Queues.newLinkedBlockingQueue();
-        SqlParser sqlParser = SqlParser.create(exeSql);
+        SqlParser.Config config = SqlParser
+                .configBuilder()
+                .setLex(Lex.JAVA)
+                .build();
+        SqlParser sqlParser = SqlParser.create(exeSql,config);
         SqlNode sqlNode = sqlParser.parseStmt();
         parseSql(sqlNode, sideTableSet, queueInfo);
         queueInfo.offer(sqlNode);

--- a/core/src/main/java/com/dtstack/flink/sql/side/SideSqlExec.java
+++ b/core/src/main/java/com/dtstack/flink/sql/side/SideSqlExec.java
@@ -642,7 +642,7 @@ public class SideSqlExec {
                 String[] filedNameArr = new String[filed.length - 1];
                 System.arraycopy(filed, 0, filedNameArr, 0, filed.length - 1);
                 String fieldName = String.join(" ", filedNameArr);
-                fieldNames.add(fieldName.toUpperCase());
+                fieldNames.add(fieldName);
                 String fieldType = filed[filed.length - 1 ].trim();
                 Class fieldClass = ClassUtil.stringConvertClass(fieldType);
                 Class tableField = table.getSchema().getType(i).get().getTypeClass();

--- a/core/src/main/java/com/dtstack/flink/sql/table/AbsTableParser.java
+++ b/core/src/main/java/com/dtstack/flink/sql/table/AbsTableParser.java
@@ -82,9 +82,6 @@ public abstract class AbsTableParser {
         String[] fieldRows = DtStringUtil.splitIgnoreQuotaBrackets(fieldsInfo, ",");
         for(String fieldRow : fieldRows){
             fieldRow = fieldRow.trim();
-            if(fieldNameNeedsUpperCase()) {
-                fieldRow = fieldRow.toUpperCase();
-            }
 
             boolean isMatcherKey = dealKeyPattern(fieldRow, tableInfo);
 


### PR DESCRIPTION
参考Flink源码，SqlParser创建默认config是java方言，不是使用oracle方言将用户标识符变为大写