### PR TITLE
feat 如果配置了group.id参数，则优先使用kafka group模式的offset。

### DIFF
--- a/kafka10/kafka10-source/src/main/java/com/dtstack/flink/sql/source/kafka/KafkaSource.java
+++ b/kafka10/kafka10-source/src/main/java/com/dtstack/flink/sql/source/kafka/KafkaSource.java
@@ -120,7 +120,9 @@ public class KafkaSource implements IStreamSourceGener<Table> {
 		}
 
 		//earliest,latest
-		if("earliest".equalsIgnoreCase(offsetReset)){
+		if (StringUtils.isNotEmpty(kafka010SourceTableInfo.getKafkaParam("group.id"))){
+			kafkaSrc.setStartFromGroupOffsets();
+		} else if("earliest".equalsIgnoreCase(offsetReset)){
 			kafkaSrc.setStartFromEarliest();
 		} else if (DtStringUtil.isJosn(offsetReset)) {// {"0":12312,"1":12321,"2":12312}
 			try {


### PR DESCRIPTION
现有的方式默认采用latest，可能发生消息丢失