### PR TITLE
支持嵌套JSON非叶子节点提取，直接转为JSON字符串

### DIFF
--- a/kafka10/kafka10-source/src/main/java/com/dtstack/flink/sql/source/kafka/CustomerJsonDeserialization.java
+++ b/kafka10/kafka10-source/src/main/java/com/dtstack/flink/sql/source/kafka/CustomerJsonDeserialization.java
@@ -126,7 +126,12 @@ public class CustomerJsonDeserialization extends AbsDeserialization<Row> {
                     }
                 } else {
                     // Read the value as specified type
-                    Object value = objectMapper.treeToValue(node, fieldTypes[i].getTypeClass());
+                    Object value;
+                    if (node.isValueNode()) {
+                      value = objectMapper.treeToValue(node, fieldTypes[i].getTypeClass());
+                    } else {
+                      value = node.toString();
+                    }
                     row.setField(i, value);
                 }
             }
@@ -144,19 +149,8 @@ public class CustomerJsonDeserialization extends AbsDeserialization<Row> {
 
     public JsonNode getIgnoreCase(String key) {
         String nodeMappingKey = rowAndFieldMapping.getOrDefault(key, key);
-        JsonNode node = nodeAndJsonNodeMapping.get(nodeMappingKey);
 
-        if(node == null){
-            return null;
-        }
-
-        JsonNodeType nodeType = node.getNodeType();
-
-        if (nodeType==JsonNodeType.ARRAY){
-            throw new IllegalStateException("Unsupported  type information  array .") ;
-        }
-
-        return node;
+        return nodeAndJsonNodeMapping.get(nodeMappingKey);
     }
 
 
@@ -166,18 +160,39 @@ public class CustomerJsonDeserialization extends AbsDeserialization<Row> {
 
     private void parseTree(JsonNode jsonNode, String prefix){
 
+      if (jsonNode.isArray()) {
+        ArrayNode array = (ArrayNode) jsonNode;
+        for (int i = 0; i < array.size(); i++) {
+          JsonNode child = array.get(i);
+          String nodeKey = getNodeKey(prefix, i);
+
+          if (child.isValueNode()) {
+            nodeAndJsonNodeMapping.put(nodeKey, child);
+          } else {
+            if (rowAndFieldMapping.containsValue(nodeKey)) {
+              nodeAndJsonNodeMapping.put(nodeKey, child);
+            }
+            parseTree(child, nodeKey);
+          }
+        }
+        return;
+      }
+
         Iterator<String> iterator = jsonNode.fieldNames();
         while (iterator.hasNext()){
             String next = iterator.next();
             JsonNode child = jsonNode.get(next);
             String nodeKey = getNodeKey(prefix, next);
 
-            if (child.isValueNode()){
-                nodeAndJsonNodeMapping.put(nodeKey, child);
-            }else {
-                parseTree(child, nodeKey);
-            }
+        if (child.isValueNode()) {
+          nodeAndJsonNodeMapping.put(nodeKey, child);
+        } else {
+          if (rowAndFieldMapping.containsValue(nodeKey)) {
+            nodeAndJsonNodeMapping.put(nodeKey, child);
+          }
+          parseTree(child, nodeKey);
         }
+      }
     }
 
     private String getNodeKey(String prefix, String nodeName){
@@ -186,6 +201,14 @@ public class CustomerJsonDeserialization extends AbsDeserialization<Row> {
         }
 
         return prefix + "." + nodeName;
+    }
+
+    private String getNodeKey(String prefix, int i) {
+      if (Strings.isNullOrEmpty(prefix)) {
+        return "[" + i + "]";
+      }
+
+      return prefix + "[" + i + "]";
     }
 
     public void setFetcher(AbstractFetcher<Row, ?> fetcher) {


### PR DESCRIPTION
嵌套json的提取，如{"a": {"b": {"c": "ccc" }, "d": [{"name": "eee"}, {"name": "e"}]}}
1、现有逻辑无法将a字段整个提取出来为一个JSON字符串；(早先不支持嵌套json，只解析一层时，子节点就是整体输出为JSON字符串，相当于这部分功能是丢失了)
2、d字段若为数组结构，无法提取出第一个数组元素，如d[0].name

修改后
CREATE TABLE source(
  a VARCHAR,
  a.b.c VARCHAR AS c,
  d[0].name VARCHAR AS name
)