### PR TITLE
kudu 数组越界修复

### DIFF
--- a/kudu/kudu-side/kudu-async-side/src/main/java/com/dtstack/flink/sql/side/kudu/KuduAsyncReqRow.java
+++ b/kudu/kudu-side/kudu-async-side/src/main/java/com/dtstack/flink/sql/side/kudu/KuduAsyncReqRow.java
@@ -127,14 +127,14 @@ public class KuduAsyncReqRow extends AsyncReqRow {
         JsonArray inputParams = new JsonArray();
         Schema schema = table.getSchema();
 
-        for (Integer conValIndex : sideInfo.getEqualValIndex()) {
-            Object equalObj = input.getField(conValIndex);
+        for (int i = 0; i < sideInfo.getEqualValIndex().size(); i++) {
+            Object equalObj = input.getField(sideInfo.getEqualValIndex().get(i));
             if (equalObj == null) {
-                resultFuture.complete(null);
+//                resultFuture.complete(null);
                 return;
             }
             //增加过滤条件
-            scannerBuilder.addPredicate(KuduPredicate.newInListPredicate(schema.getColumn(sideInfo.getEqualFieldList().get(conValIndex)), Collections.singletonList(equalObj)));
+            scannerBuilder.addPredicate(KuduPredicate.newInListPredicate(schema.getColumn(sideInfo.getEqualFieldList().get(i)), Collections.singletonList(equalObj)));
             inputParams.add(equalObj);
         }
 
@@ -230,10 +230,10 @@ public class KuduAsyncReqRow extends AsyncReqRow {
                 oneRow.put(sideFieldName, result.getFloat(sideFieldName));
                 break;
             case INT8:
-                oneRow.put(sideFieldName, result.getFloat(sideFieldName));
+                oneRow.put(sideFieldName, (int) result.getByte(sideFieldName));
                 break;
             case INT16:
-                oneRow.put(sideFieldName, result.getShort(sideFieldName));
+                oneRow.put(sideFieldName, (int) result.getShort(sideFieldName));
                 break;
             case INT32:
                 oneRow.put(sideFieldName, result.getInt(sideFieldName));

--- a/kudu/kudu-side/kudu-async-side/src/main/java/com/dtstack/flink/sql/side/kudu/KuduAsyncReqRow.java
+++ b/kudu/kudu-side/kudu-async-side/src/main/java/com/dtstack/flink/sql/side/kudu/KuduAsyncReqRow.java
@@ -130,7 +130,7 @@ public class KuduAsyncReqRow extends AsyncReqRow {
         for (int i = 0; i < sideInfo.getEqualValIndex().size(); i++) {
             Object equalObj = input.getField(sideInfo.getEqualValIndex().get(i));
             if (equalObj == null) {
-//                resultFuture.complete(null);
+                resultFuture.complete(null);
                 return;
             }
             //增加过滤条件


### PR DESCRIPTION
1.将原有的sideInfo.getEqualFieldList().get(conValIndex)改为sideInfo.getEqualFieldList().get(i)  原有写法主表和维表EqualField的index必须一致不然报错
2.将byte和short类型转换为int  原因 避免在多次left join时因为字段类型原因报:An async function call terminated with an exception. Failing the AsyncWaitOperator  Could not forward element to next operator 异常