### PR TITLE
1.set application name for yarnPer mode,2.fix double type exception in rdb sink

### DIFF
--- a/launcher/src/main/java/com/dtstack/flink/sql/launcher/perjob/PerJobClusterClientBuilder.java
+++ b/launcher/src/main/java/com/dtstack/flink/sql/launcher/perjob/PerJobClusterClientBuilder.java
@@ -103,6 +103,7 @@ public class PerJobClusterClientBuilder {
         }
 
         clusterDescriptor.addShipFiles(shipFiles);
+        clusterDescriptor.setName(launcherOptions.getName());
         String queue = launcherOptions.getQueue();
         if (!Strings.isNullOrEmpty(queue)) {
             clusterDescriptor.setQueue(queue);

--- a/rdb/rdb-side/src/main/java/com/dtstack/flink/sql/side/rdb/util/MathUtil.java
+++ b/rdb/rdb-side/src/main/java/com/dtstack/flink/sql/side/rdb/util/MathUtil.java
@@ -127,6 +127,8 @@ public class MathUtil {
             return (Double) obj;
         } else if (obj instanceof BigDecimal) {
             return ((BigDecimal) obj).doubleValue();
+        } else if (obj instanceof Double) {
+        return (Double) obj;
         }
 
         throw new RuntimeException("not support type of " + obj.getClass() + " convert to Double.");


### PR DESCRIPTION
we find  '-name'  for application name only display in flink yarn session mode,  '-name' setting not work in  yarnPer mode,  so we add this code for  customize job name in yarnPer mode, make '-name' setting work in yarnPer mode.