### PR TITLE
 完成端到端的exactly once  

### DIFF
--- a/core/src/main/java/com/dtstack/flink/sql/table/TargetTableInfo.java
+++ b/core/src/main/java/com/dtstack/flink/sql/table/TargetTableInfo.java
@@ -35,6 +35,8 @@ public abstract class TargetTableInfo extends TableInfo {
 
     private String sinkDataType = "json";
 
+    private String isExactlyOnce;
+
     public String getSinkDataType() {
         return sinkDataType;
     }
@@ -42,4 +44,13 @@ public abstract class TargetTableInfo extends TableInfo {
     public void setSinkDataType(String sinkDataType) {
         this.sinkDataType = sinkDataType;
     }
+
+    public String getIsExactlyOnce() {
+        return isExactlyOnce;
+    }
+
+    public void setIsExactlyOnce(String isExactlyOnce) {
+        this.isExactlyOnce = isExactlyOnce;
+    }
+
 }

--- a/core/src/main/java/com/dtstack/flink/sql/util/PluginUtil.java
+++ b/core/src/main/java/com/dtstack/flink/sql/util/PluginUtil.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
- 
 
 package com.dtstack.flink.sql.util;
 
@@ -42,6 +41,7 @@ import java.util.Properties;
  * Reason:
  * Date: 2018/6/27
  * Company: www.dtstack.com
+ *
  * @author xuchao
  */
 
@@ -56,11 +56,11 @@ public class PluginUtil {
     private static ObjectMapper objectMapper = new ObjectMapper();
 
 
-    public static String getJarFileDirPath(String type, String sqlRootDir){
+    public static String getJarFileDirPath(String type, String sqlRootDir) {
         String jarPath = sqlRootDir + SP + type;
         File jarFile = new File(jarPath);
 
-        if(!jarFile.exists()){
+        if (!jarFile.exists()) {
             throw new RuntimeException(String.format("path %s not exists!!!", jarPath));
         }
 
@@ -71,7 +71,7 @@ public class PluginUtil {
         String dirName = sqlRootDir + SP + pluginType + sideOperator + tableType.toLowerCase();
         File jarFile = new File(dirName);
 
-        if(!jarFile.exists()){
+        if (!jarFile.exists()) {
             throw new RuntimeException(String.format("path %s not exists!!!", dirName));
         }
 
@@ -80,30 +80,35 @@ public class PluginUtil {
 
     public static String getGenerClassName(String pluginTypeName, String type) throws IOException {
         String pluginClassName = upperCaseFirstChar(pluginTypeName) + upperCaseFirstChar(type);
-        return CLASS_PRE_STR  + "." + type.toLowerCase() + "." + pluginTypeName + "." + pluginClassName;
+        return CLASS_PRE_STR + "." + type.toLowerCase() + "." + pluginTypeName + "." + pluginClassName;
     }
 
-    public static String getSqlParserClassName(String pluginTypeName, String type){
+    public static String getRetractGenerClassName(String pluginTypeName, String type) throws IOException {
+        String pluginClassName = upperCaseFirstChar("retract") + upperCaseFirstChar(pluginTypeName) + upperCaseFirstChar(type);
+        return CLASS_PRE_STR + "." + type.toLowerCase() + "." + pluginTypeName + "." + "retract." + pluginClassName;
+    }
 
-        String pluginClassName = upperCaseFirstChar(pluginTypeName) + upperCaseFirstChar(type) +  "Parser";
-        return CLASS_PRE_STR  + "." + type.toLowerCase() + "." +  pluginTypeName + ".table." + pluginClassName;
+    public static String getSqlParserClassName(String pluginTypeName, String type) {
+
+        String pluginClassName = upperCaseFirstChar(pluginTypeName) + upperCaseFirstChar(type) + "Parser";
+        return CLASS_PRE_STR + "." + type.toLowerCase() + "." + pluginTypeName + ".table." + pluginClassName;
     }
 
 
-    public static String getSqlSideClassName(String pluginTypeName, String type, String operatorType){
+    public static String getSqlSideClassName(String pluginTypeName, String type, String operatorType) {
         String pluginClassName = upperCaseFirstChar(pluginTypeName) + operatorType + "ReqRow";
-        return CLASS_PRE_STR  + "." + type.toLowerCase() + "." +  pluginTypeName + "." + pluginClassName;
+        return CLASS_PRE_STR + "." + type.toLowerCase() + "." + pluginTypeName + "." + pluginClassName;
     }
 
-    public static Map<String,Object> ObjectToMap(Object obj) throws Exception{
+    public static Map<String, Object> ObjectToMap(Object obj) throws Exception {
         return objectMapper.readValue(objectMapper.writeValueAsBytes(obj), Map.class);
     }
 
-    public static <T> T jsonStrToObject(String jsonStr, Class<T> clazz) throws JsonParseException, JsonMappingException, JsonGenerationException, IOException{
-        return  objectMapper.readValue(jsonStr, clazz);
+    public static <T> T jsonStrToObject(String jsonStr, Class<T> clazz) throws JsonParseException, JsonMappingException, JsonGenerationException, IOException {
+        return objectMapper.readValue(jsonStr, clazz);
     }
 
-    public static Properties stringToProperties(String str) throws IOException{
+    public static Properties stringToProperties(String str) throws IOException {
         Properties properties = new Properties();
         properties.load(new ByteArrayInputStream(str.getBytes("UTF-8")));
         return properties;
@@ -130,7 +135,7 @@ public class PluginUtil {
         return buildFinalSideJarFilePath(pluginType, sideOperator, tableType, remoteSqlRootDir, localSqlPluginPath);
     }
 
-    public static URL getLocalSideJarFilePath(String pluginType, String sideOperator,  String tableType, String localSqlPluginPath) throws Exception {
+    public static URL getLocalSideJarFilePath(String pluginType, String sideOperator, String tableType, String localSqlPluginPath) throws Exception {
         return buildFinalSideJarFilePath(pluginType, sideOperator, tableType, null, localSqlPluginPath);
     }
 
@@ -143,22 +148,22 @@ public class PluginUtil {
         return new URL("file:" + sqlRootDir + SP + dirName + SP + jarName);
     }
 
-    public static String upperCaseFirstChar(String str){
+    public static String upperCaseFirstChar(String str) {
         return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 
     public static void addPluginJar(String pluginDir, DtClassLoader classLoader) throws MalformedURLException {
         File dirFile = new File(pluginDir);
-        if(!dirFile.exists() || !dirFile.isDirectory()){
+        if (!dirFile.exists() || !dirFile.isDirectory()) {
             throw new RuntimeException("plugin path:" + pluginDir + "is not exist.");
         }
 
         File[] files = dirFile.listFiles(tmpFile -> tmpFile.isFile() && tmpFile.getName().endsWith(JAR_SUFFIX));
-        if(files == null || files.length == 0){
+        if (files == null || files.length == 0) {
             throw new RuntimeException("plugin path:" + pluginDir + " is null.");
         }
 
-        for(File file : files){
+        for (File file : files) {
             URL pluginJarURL = file.toURI().toURL();
             classLoader.addURL(pluginJarURL);
         }
@@ -167,26 +172,26 @@ public class PluginUtil {
     public static URL[] getPluginJarUrls(String pluginDir) throws MalformedURLException {
         List<URL> urlList = new ArrayList<>();
         File dirFile = new File(pluginDir);
-        if(!dirFile.exists() || !dirFile.isDirectory()){
+        if (!dirFile.exists() || !dirFile.isDirectory()) {
             throw new RuntimeException("plugin path:" + pluginDir + "is not exist.");
         }
 
         File[] files = dirFile.listFiles(tmpFile -> tmpFile.isFile() && tmpFile.getName().endsWith(JAR_SUFFIX));
-        if(files == null || files.length == 0){
+        if (files == null || files.length == 0) {
             throw new RuntimeException("plugin path:" + pluginDir + " is null.");
         }
 
-        for(File file : files){
+        for (File file : files) {
             URL pluginJarURL = file.toURI().toURL();
             urlList.add(pluginJarURL);
         }
         return urlList.toArray(new URL[urlList.size()]);
     }
-    
-    public static String getCoreJarFileName (String path, String prefix) throws Exception {
+
+    public static String getCoreJarFileName(String path, String prefix) throws Exception {
         String coreJarFileName = null;
         File pluginDir = new File(path);
-        if (pluginDir.exists() && pluginDir.isDirectory()){
+        if (pluginDir.exists() && pluginDir.isDirectory()) {
             File[] jarFiles = pluginDir.listFiles(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
@@ -194,12 +199,12 @@ public class PluginUtil {
                 }
             });
 
-            if (jarFiles != null && jarFiles.length > 0){
+            if (jarFiles != null && jarFiles.length > 0) {
                 coreJarFileName = jarFiles[0].getName();
             }
         }
 
-        if (StringUtils.isEmpty(coreJarFileName)){
+        if (StringUtils.isEmpty(coreJarFileName)) {
             throw new Exception("Can not find core jar file in path:" + path);
         }
 

--- a/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractCustomerFlinkKafkaProducer011.java
+++ b/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractCustomerFlinkKafkaProducer011.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtstack.flink.sql.sink.kafka.retract;
+
+import com.dtstack.flink.sql.metric.MetricConstant;
+import com.dtstack.flink.sql.sink.kafka.CustomerJsonRowSerializationSchema;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011;
+import org.apache.flink.streaming.connectors.kafka.internals.KeyedSerializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Reason:
+ * Date: 2019/4/24
+ * Company: www.dtstack.com
+ *
+ * @author maqi
+ */
+public class RetractCustomerFlinkKafkaProducer011<Row> extends FlinkKafkaProducer011<Row> {
+
+    private static final long serialVersionUID = -613215751656348171L;
+    CustomerJsonRowSerializationSchema schema;
+
+    public RetractCustomerFlinkKafkaProducer011(String topicId, SerializationSchema<Row> serializationSchema, Properties producerConfig, Optional<FlinkKafkaPartitioner<Row>> customPartitioner) {
+        //  Too many ongoing snapshots. Increase kafka producers pool size or decrease number of concurrent checkpoints.  默认KafakProductPoolSize必须大于1
+        super(topicId, new KeyedSerializationSchemaWrapper(serializationSchema), producerConfig, customPartitioner, FlinkKafkaProducer011.Semantic.EXACTLY_ONCE, 5);
+        this.schema = (CustomerJsonRowSerializationSchema) serializationSchema;
+    }
+
+
+    @Override
+    public void open(Configuration configuration) throws Exception {
+        super.open(configuration);
+
+        RuntimeContext ctx = getRuntimeContext();
+        Counter counter = ctx.getMetricGroup().counter(MetricConstant.DT_NUM_RECORDS_OUT);
+
+        schema.setCounter(counter);
+    }
+}

--- a/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractCustomerKafka11JsonTableSink.java
+++ b/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractCustomerKafka11JsonTableSink.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtstack.flink.sql.sink.kafka.retract;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.connectors.kafka.Kafka011TableSink;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.utils.TableConnectorUtils;
+import org.apache.flink.types.Row;
+
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Reason: add schema info
+ * Date: 2019/4/8
+ * Company: www.dtstack.com
+ *
+ * @author maqi
+ */
+public class RetractCustomerKafka11JsonTableSink extends Kafka011TableSink {
+
+    protected SerializationSchema schema;
+
+
+    public RetractCustomerKafka11JsonTableSink(TableSchema schema,
+                                               String topic,
+                                               Properties properties,
+                                               Optional<FlinkKafkaPartitioner<Row>> partitioner,
+                                               SerializationSchema<Row> serializationSchema) {
+
+        super(schema, topic, properties, partitioner, serializationSchema);
+        this.schema = serializationSchema;
+    }
+
+    @Override
+    protected SinkFunction<Row> createKafkaProducer(String topic, Properties properties, SerializationSchema<Row> serializationSchema, Optional<FlinkKafkaPartitioner<Row>> optional) {
+        return new RetractCustomerFlinkKafkaProducer011<>(topic, serializationSchema, properties, optional);
+    }
+
+    @Override
+    public void emitDataStream(DataStream<Row> dataStream) {
+        SinkFunction<Row> kafkaProducer = createKafkaProducer(topic, properties, schema, partitioner);
+
+        dataStream.addSink(kafkaProducer).name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
+    }
+}

--- a/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractKafkaSink.java
+++ b/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractKafkaSink.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.flink.sql.sink.kafka.retract;
+
+import com.dtstack.flink.sql.sink.IStreamSinkGener;
+import com.dtstack.flink.sql.sink.kafka.CustomerJsonRowSerializationSchema;
+import com.dtstack.flink.sql.sink.kafka.table.KafkaSinkTableInfo;
+import com.dtstack.flink.sql.table.TargetTableInfo;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.connectors.kafka.KafkaTableSinkBase;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sinks.RetractStreamTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+import org.apache.kafka.clients.producer.ProducerConfig;
+
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * kafka result table
+ * Date: 2018/12/18
+ * Company: www.dtstack.com
+ *
+ * @author DocLi
+ * @modifyer maqi
+ */
+public class RetractKafkaSink implements RetractStreamTableSink<Row>, IStreamSinkGener<RetractKafkaSink> {
+
+    protected String[] fieldNames;
+
+    protected TypeInformation<?>[] fieldTypes;
+
+    protected String topic;
+
+    protected int parallelism;
+
+    protected Properties properties;
+
+    /**
+     * Serialization schema for encoding records to Kafka.
+     */
+    protected SerializationSchema<Row> serializationSchema;
+
+    /**
+     * The schema of the table.
+     */
+    private TableSchema schema;
+
+    /**
+     * Partitioner to select Kafka partition for each item.
+     */
+    protected Optional<FlinkKafkaPartitioner<Row>> partitioner;
+
+
+    @Override
+    public RetractKafkaSink genStreamSink(TargetTableInfo targetTableInfo) {
+        KafkaSinkTableInfo kafka11SinkTableInfo = (KafkaSinkTableInfo) targetTableInfo;
+        this.topic = kafka11SinkTableInfo.getTopic();
+
+        properties = new Properties();
+        properties.setProperty("bootstrap.servers", kafka11SinkTableInfo.getBootstrapServers());
+        //保证数据有序
+        properties.setProperty(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1");
+        //开启幂等
+        properties.setProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+
+        for (String key : kafka11SinkTableInfo.getKafkaParamKeys()) {
+            properties.setProperty(key, kafka11SinkTableInfo.getKafkaParam(key));
+        }
+        this.partitioner = Optional.of(new FlinkFixedPartitioner<>());
+        this.fieldNames = kafka11SinkTableInfo.getFields();
+        TypeInformation[] types = new TypeInformation[kafka11SinkTableInfo.getFields().length];
+        for (int i = 0; i < kafka11SinkTableInfo.getFieldClasses().length; i++) {
+            types[i] = TypeInformation.of(kafka11SinkTableInfo.getFieldClasses()[i]);
+        }
+        this.fieldTypes = types;
+
+        TableSchema.Builder schemaBuilder = TableSchema.builder();
+        for (int i = 0; i < fieldNames.length; i++) {
+            schemaBuilder.field(fieldNames[i], fieldTypes[i]);
+        }
+        this.schema = schemaBuilder.build();
+        Integer parallelism = kafka11SinkTableInfo.getParallelism();
+        if (parallelism != null) {
+            this.parallelism = parallelism;
+        }
+        this.serializationSchema = new CustomerJsonRowSerializationSchema(getOutputType().getTypeAt(1));
+        return this;
+    }
+
+    @Override
+    public TypeInformation<Row> getRecordType() {
+        return new RowTypeInfo(fieldTypes, fieldNames);
+    }
+
+    @Override
+    public void emitDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
+        KafkaTableSinkBase kafkaTableSink = new RetractCustomerKafka11JsonTableSink(
+                schema,
+                topic,
+                properties,
+                partitioner,
+                serializationSchema
+        );
+
+        DataStream<Row> ds = dataStream.flatMap((FlatMapFunction<Tuple2<Boolean, Row>, Row>)
+                (booleanRowTuple2, collector) -> {
+                    if (booleanRowTuple2.f0) {
+                        collector.collect(booleanRowTuple2.f1);
+                    }
+                }).returns(getOutputType().getTypeAt(1)).setParallelism(parallelism);
+
+//        FlinkKafkaProducer011 flinkKafkaProducer011 = new FlinkKafkaProducer011<>(topic,
+//                new KeyedSerializationSchemaWrapper<>(serializationSchema),
+//                properties,
+//                partitioner, FlinkKafkaProducer011.Semantic.EXACTLY_ONCE, 10);
+//
+//        ds.addSink(flinkKafkaProducer011).name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
+//
+
+        kafkaTableSink.emitDataStream(ds);
+    }
+
+    @Override
+    public TupleTypeInfo<Tuple2<Boolean, Row>> getOutputType() {
+        return new TupleTypeInfo(org.apache.flink.table.api.Types.BOOLEAN(), new RowTypeInfo(fieldTypes, fieldNames));
+    }
+
+    @Override
+    public String[] getFieldNames() {
+        return fieldNames;
+    }
+
+    @Override
+    public TypeInformation<?>[] getFieldTypes() {
+        return fieldTypes;
+    }
+
+    @Override
+    public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+        this.fieldNames = fieldNames;
+        this.fieldTypes = fieldTypes;
+        return this;
+    }
+}

--- a/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractKafkaSink.java
+++ b/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/retract/RetractKafkaSink.java
@@ -135,14 +135,6 @@ public class RetractKafkaSink implements RetractStreamTableSink<Row>, IStreamSin
                     }
                 }).returns(getOutputType().getTypeAt(1)).setParallelism(parallelism);
 
-//        FlinkKafkaProducer011 flinkKafkaProducer011 = new FlinkKafkaProducer011<>(topic,
-//                new KeyedSerializationSchemaWrapper<>(serializationSchema),
-//                properties,
-//                partitioner, FlinkKafkaProducer011.Semantic.EXACTLY_ONCE, 10);
-//
-//        ds.addSink(flinkKafkaProducer011).name(TableConnectorUtils.generateRuntimeName(this.getClass(), getFieldNames()));
-//
-
         kafkaTableSink.emitDataStream(ds);
     }
 

--- a/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/table/KafkaSinkParser.java
+++ b/kafka11/kafka11-sink/src/main/java/com/dtstack/flink/sql/sink/kafka/table/KafkaSinkParser.java
@@ -39,6 +39,8 @@ public class KafkaSinkParser extends AbsTableParser {
         kafka11SinkTableInfo.setName(tableName);
         parseFieldsInfo(fieldsInfo, kafka11SinkTableInfo);
         kafka11SinkTableInfo.setParallelism(MathUtil.getIntegerVal(props.get(KafkaSinkTableInfo.PARALLELISM_KEY.toLowerCase())));
+        kafka11SinkTableInfo.setIsExactlyOnce(String.valueOf(props.get("isexactlyonce")));
+
 
         if (props.get(KafkaSinkTableInfo.SINK_DATA_TYPE) != null) {
             kafka11SinkTableInfo.setSinkDataType(props.get(KafkaSinkTableInfo.SINK_DATA_TYPE).toString());


### PR DESCRIPTION
 完成端到端的exactly once  目前只支持KafkaSink11 添加KafkaSink with字段 WITH(kafka.transaction.timeout.ms='120000',isexactlyonce='true');isexactlyonce表明是否开启端到端的exactly once