### PR TITLE
解决cep不能手动指定watermark的bug

### DIFF
--- a/core/src/main/java/com/dtstack/flink/sql/exec/ExecuteProcessHelper.java
+++ b/core/src/main/java/com/dtstack/flink/sql/exec/ExecuteProcessHelper.java
@@ -80,9 +80,10 @@ import java.util.Properties;
 import java.util.Set;
 
 /**
- *  任务执行时的流程方法
+ * 任务执行时的流程方法
  * Date: 2020/2/17
  * Company: www.dtstack.com
+ *
  * @author maqi
  */
 public class ExecuteProcessHelper {
@@ -131,7 +132,8 @@ public class ExecuteProcessHelper {
     }
 
     /**
-     *   非local模式或者shipfile部署模式，remoteSqlPluginPath必填
+     * 非local模式或者shipfile部署模式，remoteSqlPluginPath必填
+     *
      * @param remoteSqlPluginPath
      * @param deployMode
      * @param pluginLoadMode
@@ -187,14 +189,14 @@ public class ExecuteProcessHelper {
         }
         return jarUrlList;
     }
-    
-    private static void sqlTranslation(String localSqlPluginPath,
-            StreamTableEnvironment tableEnv,
-            SqlTree sqlTree,Map<String, SideTableInfo> sideTableMap,
-            Map<String, Table> registerTableCache,
-            StreamQueryConfig queryConfig) throws Exception {
 
-    	SideSqlExec sideSqlExec = new SideSqlExec();
+    private static void sqlTranslation(String localSqlPluginPath,
+                                       StreamTableEnvironment tableEnv,
+                                       SqlTree sqlTree, Map<String, SideTableInfo> sideTableMap,
+                                       Map<String, Table> registerTableCache,
+                                       StreamQueryConfig queryConfig) throws Exception {
+
+        SideSqlExec sideSqlExec = new SideSqlExec();
         sideSqlExec.setLocalSqlPluginPath(localSqlPluginPath);
         for (CreateTmpTableParser.SqlParserResult result : sqlTree.getTmpSqlList()) {
             sideSqlExec.exec(result.getExecSql(), sideTableMap, tableEnv, registerTableCache, queryConfig, result);
@@ -254,13 +256,14 @@ public class ExecuteProcessHelper {
     }
 
     /**
-     *    向Flink注册源表和结果表，返回执行时插件包的全路径
+     * 向Flink注册源表和结果表，返回执行时插件包的全路径
+     *
      * @param sqlTree
      * @param env
      * @param tableEnv
      * @param localSqlPluginPath
      * @param remoteSqlPluginPath
-     * @param pluginLoadMode   插件加载模式 classpath or shipfile
+     * @param pluginLoadMode      插件加载模式 classpath or shipfile
      * @param sideTableMap
      * @param registerTableCache
      * @return
@@ -293,7 +296,23 @@ public class ExecuteProcessHelper {
 
                 if (waterMarkerAssigner.checkNeedAssignWaterMarker(sourceTableInfo)) {
                     adaptStream = waterMarkerAssigner.assignWaterMarker(adaptStream, typeInfo, sourceTableInfo);
-                    fields += ",ROWTIME.ROWTIME";
+                    String eventTimeField = sourceTableInfo.getEventTimeField();
+                    boolean hasEventTimeField = false;
+                    if (!Strings.isNullOrEmpty(eventTimeField)) {
+                        String[] fieldArray = fields.split(",");
+                        for (int i = 0; i < fieldArray.length; i++) {
+                            if (fieldArray[i].equals(eventTimeField)) {
+                                fieldArray[i] = eventTimeField + ".ROWTIME";
+                                hasEventTimeField = true;
+                                break;
+                            }
+                        }
+                        if (hasEventTimeField) {
+                            fields = String.join(",", fieldArray);
+                        } else {
+                            fields += ",ROWTIME.ROWTIME";
+                        }
+                    }
                 } else {
                     fields += ",PROCTIME.PROCTIME";
                 }
@@ -329,7 +348,8 @@ public class ExecuteProcessHelper {
     }
 
     /**
-     *   perjob模式将job依赖的插件包路径存储到cacheFile，在外围将插件包路径传递给jobgraph
+     * perjob模式将job依赖的插件包路径存储到cacheFile，在外围将插件包路径传递给jobgraph
+     *
      * @param env
      * @param classPathSet
      */


### PR DESCRIPTION
提供sql如下
CREATE TABLE datahub_stream (
    card_id                   VARCHAR,
    location                  VARCHAR,
    mytime                timestamp,
    action                  VARCHAR,
    WATERMARK FOR mytime AS withOffset(mytime,1000)
) WITH (
    type='kafka11',
    bootstrapServers='hadoop102:9092,hadoop103:9092,hadoop104:9092',
    zookeeperQuorum='hadoop102:2181,hadoop103:2181,hadoop104:2181',
    offsetReset='latest',
    groupId='csin_stream',
    topic='csin_source',
    parallelism='1',
    timezone='Asia/Shanghai'
);

CREATE TABLE rds_out (
    start_timestamp               timestamp,
    end_timestamp                 timestamp,
    card_id                       VARCHAR,
    event                         VARCHAR
) WITH (
   type='kafka11',
   bootstrapServers='hadoop102:9092,hadoop103:9092,hadoop104:9092',
   topic='csin_source2',
   parallelism='1',
   timezone='Asia/Shanghai'
);


insert into rds_out
select
start_timestamp,
end_timestamp,
card_id,event
from datahub_stream
MATCH_RECOGNIZE (
    PARTITION BY card_id
    ORDER BY mytime
    MEASURES
        e2.action as event,
        e1.mytime as start_timestamp,
        LAST(e2.mytime) as end_timestamp
    ONE ROW PER MATCH
    AFTER MATCH SKIP TO NEXT ROW
    PATTERN (e1 e2) WITHIN INTERVAL '10' MINUTE
    DEFINE
        e1 as e1.action = 'Tom',
        e2 as e2.action = 'Tom' and e2.location <> e1.location
);



