### PR TITLE
local模式taskmanager.numberOfTaskSlots指定失效问题修复

### DIFF
--- a/core/src/main/java/com/dtstack/flink/sql/environment/MyLocalStreamEnvironment.java
+++ b/core/src/main/java/com/dtstack/flink/sql/environment/MyLocalStreamEnvironment.java
@@ -105,13 +105,13 @@ public class MyLocalStreamEnvironment extends StreamExecutionEnvironment {
         configuration.addAll(jobGraph.getJobConfiguration());
 
         configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), "512M");
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS.key(), jobGraph.getMaximumParallelism());
 
         // add (and override) the settings with what the user defined
         configuration.addAll(this.conf);
 
         MiniClusterConfiguration.Builder configBuilder = new MiniClusterConfiguration.Builder();
         configBuilder.setConfiguration(configuration);
+        configBuilder.setNumSlotsPerTaskManager(jobGraph.getMaximumParallelism());
 
         if (LOG.isInfoEnabled()) {
             LOG.info("Running job on local embedded Flink mini cluster");


### PR DESCRIPTION
local模式中指定并行度大于1时，导致程序无法运行