### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -18,7 +18,7 @@
     </modules>
     <properties>
         <sql.core.version>1.0-SNAPSHOT</sql.core.version>
-        <postgresql.version>42.2.2</postgresql.version>
+        <postgresql.version>42.4.1</postgresql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.2.2
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.2.2 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS