### PR TITLE
fix(sec): upgrade org.apache.solr:solr-solrj to 8.6.3

### DIFF
--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>7.4.0</version>
+            <version>8.6.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.solr:solr-solrj 7.4.0
- [CVE-2020-13957](https://www.oscs1024.com/hd/CVE-2020-13957)


### What did I do？
Upgrade org.apache.solr:solr-solrj from 7.4.0 to 8.6.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS